### PR TITLE
fix: altitude is optional

### DIFF
--- a/backend/api/models/geo.py
+++ b/backend/api/models/geo.py
@@ -12,7 +12,7 @@ class BuildingProperties(BaseModel):
     identifier: str
     country: str
     city: str
-    altitude: int
+    altitude: int | None = None
     climate_zone: str | None = None
     age_group: str | None = None
     socioeconomic_status: str | None = None


### PR DESCRIPTION
# Describe your changes

Open Elevation service may be down, resulting in empty altitude value.
https://api.open-elevation.com/api/v1/lookup

# Related GitHub issues and pull requests

- Ref: #5
